### PR TITLE
Fixed wrong gif links if pokemon name contains special character

### DIFF
--- a/src/commands/pokemon/pokemon.js
+++ b/src/commands/pokemon/pokemon.js
@@ -42,13 +42,14 @@ module.exports = class PokemonCommand extends Command {
 
     // const oldSprite = 'http://www.pokestadium.com/sprites/xy/';
     const newSprite = 'https://play.pokemonshowdown.com/sprites/xyani/';
+    const newName = newPokemon.toLowerCase().replace(/\W/g, '');
 
     await this.client.pokemon.addPokemon(newPokemon, user);
     const catchMsg = await msg.say('<:pokeballGif:435540970554261504> catching...');
     setTimeout(() => {
       return catchMsg.edit(stripIndents`
         **${user.username}**, <:pokeball:440220815817048064> you've caught a **${newPokemon}**!
-        ${newSprite}${newPokemon.toLowerCase()}.gif
+        ${newSprite}${newName}.gif
       `);
     }, 2100);
   }


### PR DESCRIPTION
Fixes some wrong urls.

Example :
`type: null.gif` --> `typenull.gif`
`mr mime.gif` --> `mrmime.gif`

I'm just removing any non alphanumeric character from the URL.

I'm not a JS dev, this commit is not tested.

EDIT : I tested it in a NodeJS console, works.