### PR TITLE
Clarified owner-only command errors to specify "bot creator"

### DIFF
--- a/src/commands/util/blacklist.js
+++ b/src/commands/util/blacklist.js
@@ -18,7 +18,7 @@ module.exports = class BlacklistCommand extends Command {
   }
 
   async run(msg, args) {
-    if (msg.author.id !== this.client.options.owner && msg.author.id !== '220568440161697792') return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot owner can use this command!');
+    if (msg.author.id !== this.client.options.owner && msg.author.id !== '220568440161697792') return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot creator can use this command!');
     const user = args.userID;
     if (this.client.options.owner === user) return msg.reply('I\'m not gonna blacklist you!');
     const blacklist = this.client.provider.get('global', 'userBlacklist', []);

--- a/src/commands/util/eventreload.js
+++ b/src/commands/util/eventreload.js
@@ -22,7 +22,7 @@ module.exports = class EventReloadCommand extends Command {
   }
 
   run(msg, args) {
-    if (!this.client.isOwner(msg.author)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot owner can use this command!');
+    if (!this.client.isOwner(msg.author)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot creator can use this command!');
     const { event } = args;
     const dir = path.resolve('src/events');
     if (!fs.existsSync(dir)) msg.reply(':no_entry_sign: I could not load the directory.');

--- a/src/commands/util/exec.js
+++ b/src/commands/util/exec.js
@@ -21,7 +21,7 @@ module.exports = class ExecuteCommand extends Command {
   }
 
   async run(msg, args) {
-    if (!this.client.isOwner(msg.author)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot owner can use this command!');
+    if (!this.client.isOwner(msg.author)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot creator can use this command!');
     exec(args.code, (err, stdout, stderr) => {
       if (err) return msg.channel.send(err.message, { code: '' });
       return msg.channel.send(stdout, { code: '' });

--- a/src/commands/util/restart.js
+++ b/src/commands/util/restart.js
@@ -20,7 +20,7 @@ module.exports = class RestartCommand extends Command {
   }
 
   async run(msg, args) {
-    if (msg.author.id !== this.client.options.owner && !this.client.staff.includes(msg.author.id)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot owner can use this command!');
+    if (msg.author.id !== this.client.options.owner && !this.client.staff.includes(msg.author.id)) return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only a member of Toasty staff can use this command!');
     const restartType = args.restartType.toLowerCase();
     if (restartType === 'this') {
       msg.say(`\`\`\`css\nRestarting shard ${this.client.shard.id + 1}...\`\`\``);

--- a/src/commands/util/whitelist.js
+++ b/src/commands/util/whitelist.js
@@ -18,7 +18,7 @@ module.exports = class WhitelistCommand extends Command {
   }
 
   async run(msg, args) {
-    if (msg.author.id !== this.client.options.owner && msg.author.id !== '220568440161697792') return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot owner can use this command!');
+    if (msg.author.id !== this.client.options.owner && msg.author.id !== '220568440161697792') return msg.reply(':no_entry_sign: [**Invalid Permissions**]: Only the bot creator can use this command!');
     const user = args.userID;
     const blacklist = this.client.provider.get('global', 'userBlacklist', []);
     if (!blacklist.includes(user)) return msg.reply(':no_entry_sign: That user is not blacklisted.');


### PR DESCRIPTION
There has been confusion in #help related to the ambiguity of the phrase "bot owner".
Now, it specifies "bot creator", so people don't think it means an admin of any server.

(Exception: ;restart can be used by a member of Toasty staff.)